### PR TITLE
[#170]-fix no correct answer present crash

### DIFF
--- a/testomania/src/main/java/com/earth/testomania/presentation/result/ResultDataCollectorUseCase.kt
+++ b/testomania/src/main/java/com/earth/testomania/presentation/result/ResultDataCollectorUseCase.kt
@@ -1,6 +1,7 @@
 package com.earth.testomania.presentation.result
 
 import com.earth.testomania.R
+import com.earth.testomania.core.log
 import com.earth.testomania.technical.domain.model.TechQuizItemWrapper
 
 class ResultDataCollectorUseCase {
@@ -20,24 +21,36 @@ class ResultDataCollectorUseCase {
                 .filter {
                     it.selectedAnswers.isNotEmpty() && it.point == 0
                 }
-                .map { qItem ->
-                    val incIndex = qItem.selectedAnswers.find {
-                        it.userSelected
-                    }?.selectedKey ?: ""
-                    val correctIndex = qItem.quiz.correctAnswers.filter {
-                        it.value
-                    }.keys.first()
+                .map { wrappedQuizItem ->
+                    val incorrectIndex = getIncorrectIndex(wrappedQuizItem)
+                    val correctIndex = getCorrectIndex(wrappedQuizItem)
 
                     IncorrectAnsweredQuestionModel(
-                        qItem.quiz.id.toString(),
-                        qItem.quiz.question,
+                        wrappedQuizItem.quiz.id.toString(),
+                        wrappedQuizItem.quiz.question,
                         correctIndex,
-                        qItem.quiz.possibleAnswers[correctIndex] ?: "",
-                        incIndex,
-                        qItem.quiz.possibleAnswers[incIndex] ?: ""
+                        wrappedQuizItem.quiz.possibleAnswers[correctIndex] ?: "",
+                        incorrectIndex,
+                        wrappedQuizItem.quiz.possibleAnswers[incorrectIndex] ?: ""
                     )
                 }
         )
         return resultData
     }
+
+    private fun getIncorrectIndex(wrappedQuizItem: TechQuizItemWrapper): String =
+        wrappedQuizItem.selectedAnswers.find {
+            it.userSelected
+        }?.selectedKey ?: ""
+
+    private fun getCorrectIndex(wrappedQuizItem: TechQuizItemWrapper): String =
+        try {
+            wrappedQuizItem.quiz.correctAnswers.filter {
+                it.value
+            }.keys.first()
+        } catch (e: NoSuchElementException) {
+            log(e.stackTraceToString())
+            ""
+        }
+
 }

--- a/testomania/src/main/java/com/earth/testomania/technical/domain/use_case/GetQuizListUseCase.kt
+++ b/testomania/src/main/java/com/earth/testomania/technical/domain/use_case/GetQuizListUseCase.kt
@@ -118,12 +118,26 @@ class GetQuizListUseCase @Inject constructor(
         DataState.Success(
             SuccessMetaData(),
             list?.filter {
-                it.multiple_correct_answers == FALSE_STR
+                it.multiple_correct_answers == FALSE_STR && hasCorrectAnswer(it)
                 //TODO this filter is temporarily to disable multi answer quiz,
                 // but we wel remove this constraint for future on next releases of App
             }?.mapNotNull { techQuiz ->
                 convertTechQuizDTOtoDataObject(techQuiz)
             })
+
+    private fun hasCorrectAnswer(techQuizDTO: TechQuizDTO): Boolean {
+        techQuizDTO.correct_answers?.let {
+            return (
+                it.answer_a_correct.toBoolean() ||
+                it.answer_b_correct.toBoolean() ||
+                it.answer_c_correct.toBoolean() ||
+                it.answer_d_correct.toBoolean() ||
+                it.answer_e_correct.toBoolean() ||
+                it.answer_f_correct.toBoolean()
+            )
+        }
+        return false
+    }
 
     //TODO maybe for later i will move this to extension
     private fun error(dataState: DataState<List<TechQuizDTO>>) = DataState.Error(


### PR DESCRIPTION
If no correct answer comes from BE, in result screen it will appear like this
![Screenshot_20220807_013016](https://user-images.githubusercontent.com/90770974/183267566-8840b4b6-d4a1-4633-b1cb-ddf7dc99533a.png)
