### PR TITLE
Add workflow for building a bundle

### DIFF
--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -23,6 +23,9 @@ jobs:
         #        with:
         #          service_json: ${{ secrets.GOOGLE_CRASHLITYCS }}
         shell: bash
+
+
+
         run: echo $SERVICE_JSON > testomania/google-services.json
       - name: 'Create keystore file'
         with:

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: 'Checkout Code'
         uses: actions/checkout@v3
-        with:
-          ref: master
       - name: 'Set up Java'
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -30,7 +30,7 @@ jobs:
       - name: 'Build native executables'
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: buildRelease
+          arguments: bundleRelease
         env:
           KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
           KEYSTORE_PRIVATE_KEY: ${{ secrets.KEYSTORE_PRIVATE_KEY }}

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -22,10 +22,6 @@ jobs:
           SERVICE_JSON: ${{ secrets.GOOGLE_CRASHLITYCS }}
         run: |
           echo $SERVICE_JSON > testomania/google-services.json
-          cat testomania/google-services.json
-          echo $SERVICE_JSON
-          pwd
-          ls
       - name: 'Create keystore file'
         env:
           file: ${{ secrets.KEYSTORE_FILE }}
@@ -39,14 +35,9 @@ jobs:
           KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
           KEYSTORE_PRIVATE_KEY: ${{ secrets.KEYSTORE_PRIVATE_KEY }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-      - name: 'export version number'
-        id: tag
-        run: ./gradlew version | grep "versionName:" | awk '{ print "::set-output name=tag::"$2 }'
-#      - name: 'Create GitHub Release'
-#        uses: softprops/action-gh-release@v1
-#        with:
-#          files: |
-#            ./build/bin/*/releaseExecutable/google-auth-decode-*exe
-#            ./build/libs/*-all.jar
-#          tag_name: ${{steps.tag.outputs.tag}}
-#          name: version v${{steps.tag.outputs.tag}}
+      - name: 'Upload artifacts'
+      - uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: |
+            ./testomania/build/outputs/bundle/release/*

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -21,8 +21,8 @@ jobs:
         env:
           service_json: ${{ secrets.GOOGLE_CRASHLITYCS }}
         run: |
-          'echo $SERVICE_JSON > testomania/google-services.json'
-          'cat testomania/google-services.json'
+          echo $SERVICE_JSON > testomania/google-services.json
+          cat testomania/google-services.json
       - name: 'Create keystore file'
         env:
           file: ${{ secrets.KEYSTORE_FILE }}

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -27,6 +27,7 @@ jobs:
           file: ${{ secrets.KEYSTORE_FILE }}
         run: |
           echo $FILE | base64 --decode > keystore.jks
+          md5sum keystore.jks
       - name: 'Build native executables'
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -19,7 +19,7 @@ jobs:
           cache: 'gradle'
       - name: 'update google services json'
         env:
-          service_json: ${{ secrets.GOOGLE_CRASHLITYCS }}
+          SERVICE_JSON: ${{ secrets.GOOGLE_CRASHLITYCS }}
         run: |
           echo $SERVICE_JSON > testomania/google-services.json
           cat testomania/google-services.json

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -27,6 +27,8 @@ jobs:
           file: ${{ secrets.KEYSTORE_FILE }}
         run: |
           echo $FILE | base64 --decode > private_key.jks
+          pwd
+          ls
       - name: 'Build native executables'
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -20,7 +20,9 @@ jobs:
       - name: 'update google services json'
         env:
           service_json: ${{ secrets.GOOGLE_CRASHLITYCS }}
-        run: 'echo $SERVICE_JSON > testomania/google-services.json'
+        run: |
+          'echo $SERVICE_JSON > testomania/google-services.json'
+          'cat testomania/google-services.json'
       - name: 'Create keystore file'
         env:
           file: ${{ secrets.KEYSTORE_FILE }}

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -40,4 +40,4 @@ jobs:
         with:
           name: artifacts
           path: |
-            testomania/google-services.json
+            ./testomania/build/outputs/bundle/release/*

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -30,6 +30,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: buildRelease
+        env:
           KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
           KEYSTORE_PRIVATE_KEY: ${{ secrets.KEYSTORE_PRIVATE_KEY }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -40,4 +40,4 @@ jobs:
         with:
           name: artifacts
           path: |
-            ./testomania/build/outputs/bundle/release/*
+            testomania/google-services.json

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -20,11 +20,11 @@ jobs:
           distribution: temurin
           cache: 'gradle'
       - name: 'update google services json'
-        with:
+        env:
           service_json: ${{ secrets.GOOGLE_CRASHLITYCS }}
         run: 'echo $SERVICE_JSON > testomania/google-services.json'
       - name: 'Create keystore file'
-        with:
+        env:
           file: ${{ secrets.KEYSTORE_FILE }}
         run: |
           echo $FILE | base64 --decode > private_key.jks

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -36,7 +36,7 @@ jobs:
           KEYSTORE_PRIVATE_KEY: ${{ secrets.KEYSTORE_PRIVATE_KEY }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
       - name: 'Upload artifacts'
-      - uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3
         with:
           name: artifacts
           path: |

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -23,6 +23,8 @@ jobs:
         run: |
           echo $SERVICE_JSON > testomania/google-services.json
           cat testomania/google-services.json
+          pwd
+          ls
       - name: 'Create keystore file'
         env:
           file: ${{ secrets.KEYSTORE_FILE }}

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -24,14 +24,9 @@ jobs:
           echo $SERVICE_JSON > testomania/google-services.json
       - name: 'Create keystore file'
         env:
-          file: ${{ secrets.KEYSTORE_FILE }}
+          FILE: ${{ secrets.KEYSTORE_FILE }}
         run: |
-          echo $FILE | base64 --decode > kee1
-      - name: 'Upload artifacts'
-        uses: actions/upload-artifact@v3
-        with:
-          name: artifacts
-          path: kee1
+          echo $FILE | base64 --decode > keystore.jks
       - name: 'Build native executables'
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -1,4 +1,4 @@
-name: 'Build and release'
+name: 'Build artifacts'
 
 on: workflow_dispatch
 
@@ -20,9 +20,9 @@ jobs:
           distribution: temurin
           cache: 'gradle'
       - name: 'update google services json'
-        run: echo $SERVICE_JSON > testomania/google-services.json
         with:
           service_json: ${{ secrets.GOOGLE_CRASHLITYCS }}
+        run: echo $SERVICE_JSON > testomania/google-services.json
       - name: 'Create keystore file'
         with:
           file: ${{ secrets.KEYSTORE_FILE }}

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           echo $SERVICE_JSON > testomania/google-services.json
           cat testomania/google-services.json
+          echo $SERVICE_JSON
           pwd
           ls
       - name: 'Create keystore file'

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -26,8 +26,13 @@ jobs:
         env:
           file: ${{ secrets.KEYSTORE_FILE }}
         run: |
-          echo $FILE | base64 --decode > keystore.jks
+          echo $FILE | base64 --decode > kee1
           md5sum keystore.jks
+      - name: 'Upload artifacts'
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: kee1
       - name: 'Build native executables'
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -22,6 +22,7 @@ jobs:
       - name: 'update google services json'
         #        with:
         #          service_json: ${{ secrets.GOOGLE_CRASHLITYCS }}
+        shell: bash
         run: echo $SERVICE_JSON > testomania/google-services.json
       - name: 'Create keystore file'
         with:

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -27,8 +27,6 @@ jobs:
           file: ${{ secrets.KEYSTORE_FILE }}
         run: |
           echo $FILE | base64 --decode > keystore.jks
-          pwd
-          ls
       - name: 'Build native executables'
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -20,8 +20,8 @@ jobs:
           distribution: temurin
           cache: 'gradle'
       - name: 'update google services json'
-        with:
-          service_json: ${{ secrets.GOOGLE_CRASHLITYCS }}
+        #        with:
+        #          service_json: ${{ secrets.GOOGLE_CRASHLITYCS }}
         run: echo $SERVICE_JSON > testomania/google-services.json
       - name: 'Create keystore file'
         with:

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -27,7 +27,6 @@ jobs:
           file: ${{ secrets.KEYSTORE_FILE }}
         run: |
           echo $FILE | base64 --decode > kee1
-          md5sum keystore.jks
       - name: 'Upload artifacts'
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           file: ${{ secrets.KEYSTORE_FILE }}
         run: |
-          echo $FILE | base64 --decode > private_key.jks
+          echo $FILE | base64 --decode > keystore.jks
           pwd
           ls
       - name: 'Build native executables'

--- a/.github/workflows/gradle-buildRelease.yml
+++ b/.github/workflows/gradle-buildRelease.yml
@@ -20,13 +20,9 @@ jobs:
           distribution: temurin
           cache: 'gradle'
       - name: 'update google services json'
-        #        with:
-        #          service_json: ${{ secrets.GOOGLE_CRASHLITYCS }}
-        shell: bash
-
-
-
-        run: echo $SERVICE_JSON > testomania/google-services.json
+        with:
+          service_json: ${{ secrets.GOOGLE_CRASHLITYCS }}
+        run: 'echo $SERVICE_JSON > testomania/google-services.json'
       - name: 'Create keystore file'
         with:
           file: ${{ secrets.KEYSTORE_FILE }}

--- a/.github/workflows/gradle-bundleRelease.yml
+++ b/.github/workflows/gradle-bundleRelease.yml
@@ -1,10 +1,10 @@
-name: 'Build artifacts'
+name: 'Build App Bundle'
 
 on: workflow_dispatch
 
 jobs:
   build:
-    name: 'Build the project'
+    name: 'Build the project and create .aab file for Play Store'
     runs-on: ubuntu-latest
     outputs:
       tag-name: ${{ steps.tag.outputs.tag }}

--- a/testomania/build.gradle
+++ b/testomania/build.gradle
@@ -29,7 +29,7 @@ android {
         release {
             keyAlias System.getenv("KEYSTORE_ALIAS")
             keyPassword System.getenv("KEYSTORE_PRIVATE_KEY")
-            storeFile file("./keystore.jks")
+            storeFile file("../keystore.jks")
             storePassword System.getenv("KEYSTORE_PASSWORD")
         }
     }

--- a/testomania/build.gradle
+++ b/testomania/build.gradle
@@ -29,7 +29,7 @@ android {
         release {
             keyAlias System.getenv("KEYSTORE_ALIAS")
             keyPassword System.getenv("KEYSTORE_PRIVATE_KEY")
-            storeFile file(System.getProperty("user.home") + "/keystore.jks")
+            storeFile file("./keystore.jks")
             storePassword System.getenv("KEYSTORE_PASSWORD")
         }
     }


### PR DESCRIPTION
Triggering this workflow will replace google-services.json to a production variant, build bundle and sign it.

A downloadable file should appear when opening the workflow run. For example:
https://github.com/Nodrex/Testomania/actions/runs/2852698765