### PR TITLE
Converted api key from query param in to header

### DIFF
--- a/testomania/src/main/kotlin/com/earth/testomania/apis/quiz/quizapi/data/source/QuizApi.kt
+++ b/testomania/src/main/kotlin/com/earth/testomania/apis/quiz/quizapi/data/source/QuizApi.kt
@@ -3,6 +3,7 @@ package com.earth.testomania.apis.quiz.quizapi.data.source
 import com.earth.testomania.apis.quiz.quizapi.data.source.remote.dto.TechQuizDTO
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.Query
 
 const val QUIZ_API_KEY = "rQY0VtcCgMPYMPxEL9f8bxZdmM2gfogf6QhkuKZa"
@@ -12,7 +13,7 @@ interface QuizApi {
 
     @GET(QUIZ_API_PATH)
     suspend fun getQuizList(
-        @Query("apiKey") apiKey: String = QUIZ_API_KEY,
+        @Header("X-Api-Key") apiKey: String = QUIZ_API_KEY,
         @Query("limit") questionCount: Int = 20,
         @Query("category") category: String? = null,
         @Query("tags") tags: String? = null


### PR DESCRIPTION
this is recommended by official docs of QuizApi: https://quizapi.io/docs/1.0/authentication#:~:text=We%20strongly%20recommend%20option%202%20so%20that%20your%20API%20key%20isn%27t%20visible%20to%20others%20in%20logs%20or%20request%20sniffing.